### PR TITLE
No more removelast

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -328,7 +328,6 @@ chore: update dependencies
 ## Questions?
 
 - Open an [issue](https://github.com/dosier/kodio/issues) for bugs or feature requests
-- Start a [discussion](https://github.com/dosier/kodio/discussions) for questions
 
 Thank you for contributing! 🎉
 

--- a/kodio-extensions/compose/src/commonMain/kotlin/space/kodio/compose/AudioWaveform.kt
+++ b/kodio-extensions/compose/src/commonMain/kotlin/space/kodio/compose/AudioWaveform.kt
@@ -104,7 +104,7 @@ fun AudioWaveform(
     LaunchedEffect(amplitudes.size) {
         // Resize the list to match input
         while (animatedAmplitudes.size > amplitudes.size) {
-            animatedAmplitudes.removeLast()
+            animatedAmplitudes.removeAt(animatedAmplitudes.lastIndex)
         }
         while (animatedAmplitudes.size < amplitudes.size) {
             animatedAmplitudes.add(Animatable(0f))


### PR DESCRIPTION
I got a warning when trying to publish an app with Kodio to the play store:

<img width="1355" height="237" alt="image" src="https://github.com/user-attachments/assets/9b49c84e-d765-4421-9faf-a1fc499aa732" />

(See more -> https://developer.android.com/about/versions/15/behavior-changes-15#kotlin-remove-first)

I think it should be a pretty easy fix. Also deleted the line about `discussions` in the CONTRIBUTING, I think that is disabled.